### PR TITLE
Enable major ticks on charts

### DIFF
--- a/src/components/entities/chart/Chart.tsx
+++ b/src/components/entities/chart/Chart.tsx
@@ -1069,6 +1069,7 @@ export const Chart = ({
               autoSkip: true,
               autoSkipPadding: 50,
               maxRotation: 0,
+              major: { enabled: true },
             },
             grid: {
               display: !compact,


### PR DESCRIPTION
Improves but does not solve https://github.com/nasa-jpl/mango-ui/issues/64. Need to further investigate ChartJS solutions for formatting major tick labels as the day/month disappears once you zoom in far enough. This is somewhat standard behavior for charting libraries but it would be good to preserve context while zoomed. If this is not feasible within ChartJS we'll need to look into other options for displaying context date while zoomed.