### PR TITLE
Config based date bounds with admin controls

### DIFF
--- a/src/components/app/ProductPreviewModal.tsx
+++ b/src/components/app/ProductPreviewModal.tsx
@@ -134,7 +134,7 @@ export const ProductPreviewModal = ({
 
   const computedDateBounds = dateBounds || {
     start: "2010T00:00:00Z",
-    end: "2040T00:00:00Z",
+    end: "2050T00:00:00Z",
   };
 
   return (

--- a/src/components/app/ProductPreviewModal.tsx
+++ b/src/components/app/ProductPreviewModal.tsx
@@ -24,6 +24,7 @@ const getProductDisplayName = (product: Product, instrument?: string) => {
 };
 
 export declare type ProductPreviewModalProps = {
+  dateBounds?: DateRange;
   dateRange?: DateRange | undefined;
   field?: string;
   instrument?: string;
@@ -38,6 +39,7 @@ export const ProductPreviewModal = ({
   product,
   products,
   instrument,
+  dateBounds,
   version: defaultVersion = "",
   dateRange: defaultDateRange,
   field: defaultField = "",
@@ -128,6 +130,11 @@ export const ProductPreviewModal = ({
       return c;
     });
     setChannels(newChannels);
+  };
+
+  const computedDateBounds = dateBounds || {
+    start: "2010T00:00:00Z",
+    end: "2040T00:00:00Z",
   };
 
   return (
@@ -226,10 +233,13 @@ export const ProductPreviewModal = ({
                   start: startDate.toISOString(),
                 });
               }}
+              minDate={new Date(computedDateBounds.start)}
+              maxDate={new Date(computedDateBounds.end)}
             />
           </div>
           <div className="flex flex-1 flex-col h-0 border rounded overflow-hidden">
             <Chart
+              dateBounds={computedDateBounds}
               enableEditing={false}
               chartEntity={chartEntity}
               products={products}

--- a/src/components/entities/chart/Chart.tsx
+++ b/src/components/entities/chart/Chart.tsx
@@ -76,8 +76,8 @@ let tooltipRoot: Root;
 export declare type ChartProps = {
   chartEntity: ChartEntity;
   compact?: boolean;
-  dateRange: DateRange;
   dateBounds: DateRange;
+  dateRange: DateRange;
   enableEditing?: boolean;
   hoverDate: Date | null;
   instrument?: string | null;

--- a/src/components/entities/chart/Chart.tsx
+++ b/src/components/entities/chart/Chart.tsx
@@ -77,6 +77,7 @@ export declare type ChartProps = {
   chartEntity: ChartEntity;
   compact?: boolean;
   dateRange: DateRange;
+  dateBounds: DateRange;
   enableEditing?: boolean;
   hoverDate: Date | null;
   instrument?: string | null;
@@ -118,6 +119,7 @@ export const Chart = ({
   chartEntity,
   products,
   dateRange,
+  dateBounds,
   instrument: instrumentProp,
   mission: missionProp,
   compact = false,
@@ -1107,6 +1109,12 @@ export const Chart = ({
             algorithm: "min-max",
           },
           zoom: {
+            limits: {
+              x: {
+                min: new Date(dateBounds.start).getTime(),
+                max: new Date(dateBounds.end).getTime(),
+              },
+            },
             zoom: {
               wheel: {
                 enabled: true,

--- a/src/components/entities/timeline-row/TimelineRow.tsx
+++ b/src/components/entities/timeline-row/TimelineRow.tsx
@@ -13,6 +13,7 @@ import "./TimelineRow.css";
 
 export declare type TimelineRowProps = {
   dateRange: DateRange;
+  dateBounds: DateRange;
   hoverDate: Date | null;
   instrument?: string | null;
   loading?: boolean;
@@ -31,6 +32,7 @@ export declare type TimelineRowProps = {
 export function TimelineRow({
   timelineRowEntity,
   dateRange,
+  dateBounds,
   marginLeft,
   products,
   hoverDate,
@@ -72,6 +74,7 @@ export function TimelineRow({
           loading={loading}
           entity={timelineRowEntity.entity}
           dateRange={dateRange}
+          dateBounds={dateBounds}
           hoverDate={hoverDate}
           products={products}
           showHeader={false}
@@ -129,6 +132,7 @@ export function TimelineRow({
                   entity={entity}
                   loading={loading}
                   dateRange={dateRange}
+                  dateBounds={dateBounds}
                   hoverDate={hoverDate}
                   products={products}
                   showHeader={false}

--- a/src/components/entities/timeline-row/TimelineRow.tsx
+++ b/src/components/entities/timeline-row/TimelineRow.tsx
@@ -12,8 +12,8 @@ import StatusBadge from "../../ui/StatusBadge";
 import "./TimelineRow.css";
 
 export declare type TimelineRowProps = {
-  dateRange: DateRange;
   dateBounds: DateRange;
+  dateRange: DateRange;
   hoverDate: Date | null;
   instrument?: string | null;
   loading?: boolean;

--- a/src/components/mission/GRACE/DownlinkDashboard.tsx
+++ b/src/components/mission/GRACE/DownlinkDashboard.tsx
@@ -35,8 +35,8 @@ import TimelineRow from "../../entities/timeline-row/TimelineRow";
 import Timeline from "../../entities/timeline/Timeline";
 
 export declare type DownlinkDashboardProps = {
-  dateRange: DateRange;
   dateBounds: DateRange;
+  dateRange: DateRange;
   downlinkDashboardEntity: DownlinkDashboardEntity;
   hoverDate: Date | null;
   instrument?: string | null;

--- a/src/components/mission/GRACE/DownlinkDashboard.tsx
+++ b/src/components/mission/GRACE/DownlinkDashboard.tsx
@@ -36,6 +36,7 @@ import Timeline from "../../entities/timeline/Timeline";
 
 export declare type DownlinkDashboardProps = {
   dateRange: DateRange;
+  dateBounds: DateRange;
   downlinkDashboardEntity: DownlinkDashboardEntity;
   hoverDate: Date | null;
   instrument?: string | null;
@@ -56,6 +57,7 @@ type DownlinkDashData = {
 export function DownlinkDashboard({
   downlinkDashboardEntity,
   dateRange,
+  dateBounds,
   products,
   hoverDate,
   selectedPoint,
@@ -771,6 +773,7 @@ export function DownlinkDashboard({
           status={datasetStatus}
           loading={loading}
           dateRange={dateRange}
+          dateBounds={dateBounds}
           mission={mission}
           instrument={instrument}
           products={products}

--- a/src/components/page/Entity.tsx
+++ b/src/components/page/Entity.tsx
@@ -25,8 +25,8 @@ import { DownlinkDashboard } from "../mission/GRACE/DownlinkDashboard";
 export declare type EntityProps = {
   className?: string;
   compact?: boolean;
-  dateRange: DateRange;
   dateBounds: DateRange;
+  dateRange: DateRange;
   enableEditing?: boolean;
   entity: EntityType;
   hoverDate: Date | null; // TODO could this be Date | undefined and made optional?

--- a/src/components/page/Entity.tsx
+++ b/src/components/page/Entity.tsx
@@ -26,6 +26,7 @@ export declare type EntityProps = {
   className?: string;
   compact?: boolean;
   dateRange: DateRange;
+  dateBounds: DateRange;
   enableEditing?: boolean;
   entity: EntityType;
   hoverDate: Date | null; // TODO could this be Date | undefined and made optional?
@@ -53,6 +54,7 @@ export const Entity = (props: EntityProps) => {
     products,
     entity,
     dateRange,
+    dateBounds,
     hoverDate,
     instrument = null,
     mission = null,
@@ -82,6 +84,7 @@ export const Entity = (props: EntityProps) => {
           loading={loading}
           chartEntity={entity}
           dateRange={dateRange}
+          dateBounds={dateBounds}
           hoverDate={hoverDate}
           instrument={instrument}
           mission={mission}
@@ -134,6 +137,7 @@ export const Entity = (props: EntityProps) => {
         <DownlinkDashboard
           downlinkDashboardEntity={entity as DownlinkDashboardEntity}
           dateRange={dateRange}
+          dateBounds={dateBounds}
           products={products}
           hoverDate={hoverDate}
           instrument={instrument}

--- a/src/components/page/Section.tsx
+++ b/src/components/page/Section.tsx
@@ -29,8 +29,8 @@ import Entity from "./Entity";
 import "./Section.css";
 
 export declare type SectionProps = {
-  dateRange: DateRange;
   dateBounds: DateRange;
+  dateRange: DateRange;
   hoverDate: Date | null;
   instrument?: string | null;
   mission?: string | null;

--- a/src/components/page/Section.tsx
+++ b/src/components/page/Section.tsx
@@ -30,6 +30,7 @@ import "./Section.css";
 
 export declare type SectionProps = {
   dateRange: DateRange;
+  dateBounds: DateRange;
   hoverDate: Date | null;
   instrument?: string | null;
   mission?: string | null;
@@ -51,6 +52,7 @@ export declare type SectionProps = {
 
 export const Section = ({
   dateRange,
+  dateBounds,
   hoverDate,
   products,
   section,
@@ -143,6 +145,7 @@ export const Section = ({
       products={products}
       entity={e}
       onDateRangeChange={onDateRangeChange}
+      dateBounds={dateBounds}
       onDelete={() => onEntityDelete(e, section)}
       onDuplicate={() => onEntityDuplicate(e, section)}
       onEdit={() => onEntityEdit(e, section)}

--- a/src/components/page/ViewPage.tsx
+++ b/src/components/page/ViewPage.tsx
@@ -38,6 +38,7 @@ import { Tooltip } from "../ui/Tooltip";
 import Section from "./Section";
 
 export declare type PageProps = {
+  dateBounds?: DateRange;
   loadingInitialData: boolean;
   onPageChange: (page: PageType) => void;
   onSetProductPreview: (productPreview: ProductPreview) => void;
@@ -47,6 +48,10 @@ export declare type PageProps = {
 
 // TODO consider if we need to disambiguate View<Page|Entity|Section> from the component names?
 export const ViewPage = ({
+  dateBounds = {
+    start: "2010-12-01T00:00:00Z",
+    end: "2050-12-01T00:00:00Z",
+  },
   products,
   loadingInitialData,
   viewPage,
@@ -309,6 +314,8 @@ export const ViewPage = ({
                 end: endDate.toISOString(),
               });
             }}
+            minDate={new Date(dateBounds.start)}
+            maxDate={new Date(dateBounds.end)}
           />
 
           <DropdownMenu>
@@ -396,6 +403,7 @@ export const ViewPage = ({
           onCancel={() => setEntityToEdit(null)}
           onSave={onEntitySave}
           dateRange={dateRange}
+          dateBounds={dateBounds}
           onDateRangeChange={setDateRange}
           products={products}
         />
@@ -408,6 +416,7 @@ export const ViewPage = ({
             section={section}
             key={section.id}
             dateRange={dateRange}
+            dateBounds={dateBounds}
             mission={viewPage.missions ? mission : null}
             instrument={viewPage.missions ? instrument : null}
             hoverDate={pageOptions.showHoverDate ? hoverDate : null}

--- a/src/components/ui/EntityEditor.tsx
+++ b/src/components/ui/EntityEditor.tsx
@@ -51,6 +51,7 @@ import { Tooltip } from "./Tooltip";
 
 export declare type EntityEditorProps = {
   dateRange: DateRange;
+  dateBounds: DateRange;
   entity: EntityType;
   onCancel: () => void;
   onDateRangeChange: (dateRange: DateRange) => void;
@@ -115,6 +116,7 @@ const extractEntitySelectedProducts = (
 export const EntityEditor = ({
   entity,
   dateRange,
+  dateBounds,
   onCancel,
   onSave,
   onDateRangeChange,
@@ -302,6 +304,7 @@ export const EntityEditor = ({
               entity={newEntity}
               products={products}
               dateRange={dateRange}
+              dateBounds={dateBounds}
               onDateRangeChange={onDateRangeChange}
               hoverDate={null}
               onSelectPoint={() => {}}

--- a/src/components/ui/EntityEditor.tsx
+++ b/src/components/ui/EntityEditor.tsx
@@ -50,8 +50,8 @@ import ProductsSelector from "./ProductsSelector";
 import { Tooltip } from "./Tooltip";
 
 export declare type EntityEditorProps = {
-  dateRange: DateRange;
   dateBounds: DateRange;
+  dateRange: DateRange;
   entity: EntityType;
   onCancel: () => void;
   onDateRangeChange: (dateRange: DateRange) => void;

--- a/src/routes/ManagementPage.tsx
+++ b/src/routes/ManagementPage.tsx
@@ -16,6 +16,7 @@ import { ArrowDown, ArrowUp, Copy, Trash2 } from "lucide-react";
 import { FormEvent, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 import { z } from "zod";
+import { DateRangePicker } from "../components/ui/DateRangePicker";
 import { InputForm } from "../components/ui/InputForm";
 import Page from "../components/ui/Page";
 import { Tooltip } from "../components/ui/Tooltip";
@@ -326,6 +327,32 @@ export default function ManagementPage() {
               });
             }}
           />
+
+          <div className="flex flex-1 mt-6 flex-col gap-1">
+            <Label size="sm">Date Range Bounds</Label>
+            <DateRangePicker
+              startDate={
+                new Date(view.config?.dateRangeBounds?.start || "2010T00:00:00")
+              }
+              endDate={
+                new Date(view.config?.dateRangeBounds?.end || "2050T00:00:00")
+              }
+              onChange={(startDate: Date, endDate: Date) => {
+                const config = view.config || {};
+                setView({
+                  ...view,
+                  config: {
+                    ...config,
+                    dateRangeBounds: {
+                      end: endDate.toISOString(),
+                      start: startDate.toISOString(),
+                    },
+                  },
+                });
+              }}
+            />
+          </div>
+
           {view.pageGroups.map((pageGroup, i) => {
             const otherPageGroups = view.pageGroups.filter(
               (p) => p.id !== pageGroup.id

--- a/src/routes/RootPage.tsx
+++ b/src/routes/RootPage.tsx
@@ -100,6 +100,7 @@ export default function RootPage() {
       <Outlet context={context} />
       {!loadingInitialData && (
         <ProductPreviewModal
+          dateBounds={view.config?.dateRangeBounds}
           onClose={() => setProductPreview({ product: undefined })}
           products={products}
           {...productPreview}

--- a/src/routes/ViewPage.tsx
+++ b/src/routes/ViewPage.tsx
@@ -40,6 +40,7 @@ export default function ViewPage() {
       products={products}
       loadingInitialData={loadingInitialData}
       viewPage={page}
+      dateBounds={view.config?.dateRangeBounds}
       onSetProductPreview={setProductPreview}
       onPageChange={(page: ViewPageType) => {
         const newView = {

--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -9,6 +9,7 @@ import { DateRange } from "./time";
 
 export type View = {
   config?: {
+    dateRangeBounds?: DateRange;
     sidebarWidth?: number;
   };
   home: Page;

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -215,7 +215,13 @@ export function formatYValue(tickValue: number | string): string {
 
 export function createView(): View {
   return {
-    config: { sidebarWidth: 200 },
+    config: {
+      sidebarWidth: 200,
+      dateRangeBounds: {
+        start: "2010-12-01T00:00:00Z",
+        end: "2050-12-01T00:00:00Z",
+      },
+    },
     home: createViewPage({}),
     pageGroups: [],
     version: VIEW_VERSION,


### PR DESCRIPTION
Closes #89. Does not limit zoom of individual charts to the bounds of their datasets since viewing multiple charts at a time may create the situation where a user wants to zoom out past the bounds of one dataset to see data in a chart with a broader range.