### PR TITLE
Added quick filter to products page

### DIFF
--- a/e2e-tests/utilities/product.ts
+++ b/e2e-tests/utilities/product.ts
@@ -5,9 +5,11 @@ export const generateTestDataset = (): Dataset => {
   return {
     data_begin: "2022-01-01T00:00:00.037430+00:00",
     data_end: "2023-01-01T00:00:00.037430+00:00",
+    dataset_id: generateUniqueName(),
     instrument_id: "C",
     last_updated: "2024-01-01T00:00:00.037430+00:00",
-    product: generateUniqueName(),
+    product_id: generateUniqueName(),
+    version_id: "04",
   };
 };
 

--- a/src/components/app/ProductTable.tsx
+++ b/src/components/app/ProductTable.tsx
@@ -102,11 +102,11 @@ export const ProductTable = ({
       valueGetter: (params) => params.data?.datasets[0].data_end,
     },
     {
-      field: "available_versions",
       filter: "string",
-      headerName: "Versions",
+      headerName: "Version",
       resizable: true,
       width: 100,
+      valueGetter: (params) => params.data?.datasets[0].version_id,
     },
     {
       field: "available_fields",
@@ -130,11 +130,13 @@ export const ProductTable = ({
         resolutions.map((r: ProductResolution) => r.downsampling_factor),
     },
   ];
+
   return (
     <DataGrid<Product>
       rowData={productEntries}
       columnDefs={columnDefs}
       loading={loading}
+      showQuickFilter={true}
       className="[&_div[role='row']:not(:hover)_.product-preview-button]:opacity-0 [&_div[role='row']:not(:hover)_.product-preview-button]:pointer-events-none"
     />
   );

--- a/src/components/ui/DataGrid/DataGrid.tsx
+++ b/src/components/ui/DataGrid/DataGrid.tsx
@@ -143,8 +143,8 @@ export function DataGrid<T>({
       style={{
         height: "100%",
         width: "100%",
-        overflow: "hidden",
-        padding: "2px",
+        display: "flex",
+        flexDirection: "column",
       }}
     >
       {showQuickFilter && (
@@ -153,6 +153,7 @@ export function DataGrid<T>({
             autoComplete="off"
             type="text"
             id="filter-text-box"
+            sizeVariant="sm"
             placeholder="Filter..."
             onInput={onFilterTextBoxChanged}
           />

--- a/src/components/ui/DataGrid/DataGrid.tsx
+++ b/src/components/ui/DataGrid/DataGrid.tsx
@@ -3,7 +3,7 @@ import {
   SizeColumnsToFitGridStrategy,
   SizeColumnsToFitProvidedWidthStrategy,
 } from "@ag-grid-community/core";
-import { cn } from "@nasa-jpl/stellar-react";
+import { cn, Input } from "@nasa-jpl/stellar-react";
 import { IRowNode } from "ag-grid-community";
 import "ag-grid-community/styles/ag-grid.css"; // Core CSS
 import {
@@ -44,6 +44,7 @@ export declare type DataGridProps<T> = {
   onRowSelected?: (row: T | null) => void;
   rowData: T[];
   selectedItemId?: string | undefined;
+  showQuickFilter?: boolean;
 };
 
 export function DataGrid<T>({
@@ -55,12 +56,23 @@ export function DataGrid<T>({
   compact = false,
   fitToGridWidth = false,
   loading = true,
+  showQuickFilter = false,
   className = "",
   gridProps = {},
   error,
 }: DataGridProps<T>) {
   const gridRef = useRef<AgGridReact>(null);
   const [gridReady, setGridReady] = useState(false);
+
+  useEffect(() => {
+    if (gridRef.current?.api && gridReady) {
+      const quickFilterText = gridProps.quickFilterText;
+      if (quickFilterText !== undefined) {
+        // @ts-expect-error - ag-grid types might be outdated
+        gridRef.current.api.setQuickFilter(quickFilterText);
+      }
+    }
+  }, [gridProps.quickFilterText, gridReady]);
 
   useEffect(() => {
     if (gridRef.current && gridRef.current.api && gridReady) {
@@ -124,6 +136,15 @@ export function DataGrid<T>({
     };
   }, [error]);
 
+  const onFilterTextBoxChanged = (event: React.FormEvent<HTMLInputElement>) => {
+    if (gridRef.current?.api) {
+      gridRef.current.api.setGridOption(
+        "quickFilterText",
+        event.currentTarget.value
+      );
+    }
+  };
+
   return (
     <div
       className={classNames("ag-theme-stellar", {
@@ -131,6 +152,16 @@ export function DataGrid<T>({
       })}
       style={{ height: "100%", width: "100%" }}
     >
+      {showQuickFilter && (
+        <div className="mb-4" style={{ width: "25%" }}>
+          <Input
+            type="text"
+            id="filter-text-box"
+            placeholder="Filter..."
+            onInput={onFilterTextBoxChanged}
+          />
+        </div>
+      )}
       <AgGridReact<T>
         ref={gridRef}
         suppressColumnVirtualisation

--- a/src/components/ui/DataGrid/DataGrid.tsx
+++ b/src/components/ui/DataGrid/DataGrid.tsx
@@ -65,16 +65,6 @@ export function DataGrid<T>({
   const [gridReady, setGridReady] = useState(false);
 
   useEffect(() => {
-    if (gridRef.current?.api && gridReady) {
-      const quickFilterText = gridProps.quickFilterText;
-      if (quickFilterText !== undefined) {
-        // @ts-expect-error - ag-grid types might be outdated
-        gridRef.current.api.setQuickFilter(quickFilterText);
-      }
-    }
-  }, [gridProps.quickFilterText, gridReady]);
-
-  useEffect(() => {
     if (gridRef.current && gridRef.current.api && gridReady) {
       if (!selectedItemId || !idKey) {
         gridRef.current.api.deselectAll();
@@ -150,11 +140,17 @@ export function DataGrid<T>({
       className={classNames("ag-theme-stellar", {
         "ag-theme-stellar--compact": compact,
       })}
-      style={{ height: "100%", width: "100%" }}
+      style={{
+        height: "100%",
+        width: "100%",
+        overflow: "hidden",
+        padding: "2px",
+      }}
     >
       {showQuickFilter && (
-        <div className="mb-4" style={{ width: "25%" }}>
+        <div className="mb-4 w-[25%] min-w-[300px]">
           <Input
+            autoComplete="off"
             type="text"
             id="filter-text-box"
             placeholder="Filter..."
@@ -176,6 +172,7 @@ export function DataGrid<T>({
         }}
         loading={loading}
         columnDefs={columnDefs}
+        quickFilterText={gridProps.quickFilterText}
         enableBrowserTooltips={true}
         animateRows={false}
         suppressCellFocus

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -26,12 +26,16 @@ export type Dataset = {
   data_begin: string;
   /* time of last entry */
   data_end: string;
+  /* <mission>_<product>_<version>_<instrument> */
+  dataset_id: string;
   /* ID of instrument */
   instrument_id: string;
   /* time of last update */
   last_updated: string;
   /* <mission>_<product_id> */
-  product: string;
+  product_id: string;
+  /* version of the product */
+  version_id: string;
 };
 
 export type ProductField = {


### PR DESCRIPTION
- added ag-grid quick-filter to Products page for easy filtering against the entire page
- extended Datagrid component props to optionally add quick filter (default is False)
- removed "available versions" column and added "version" column so that different versions of the same product type will appear on different rows
- updated Dataset type definition to included updated types returned from the API
- updated tests to conform to updated Dataset type

Closes #145 