### PR TITLE
Formatted time to GPS time

### DIFF
--- a/e2e-tests/utilities/product.ts
+++ b/e2e-tests/utilities/product.ts
@@ -45,7 +45,7 @@ export const generateTestProduct = (): Product => {
     full_id: generateUniqueName(),
     id: generateUniqueName(),
     instruments: ["C", "D"],
-    mission: generateUniqueName(),
+    mission: { id: "MISSION", label: "MISSION" },
     processing_level: "1A",
     query_result_limit: 1000,
     timestamp_field: generateUniqueName(),

--- a/public/default-view.json
+++ b/public/default-view.json
@@ -6,18 +6,33 @@
         "id": "dsfgr23rwe",
         "type": "section",
         "title": "Examples",
-        "layout": [{ "h": 4, "i": "3erwgdfnb", "w": 12, "x": 8, "y": 0 }],
+        "layout": [
+          {
+            "h": 4,
+            "i": "3erwgdfnb",
+            "w": 12,
+            "x": 8,
+            "y": 0
+          }
+        ],
         "entities": [
           {
             "id": "3erwgdfnb",
             "type": "chart",
             "title": "ACC1A",
-            "yAxes": [{ "id": "y1", "position": "left" }],
+            "yAxes": [
+              {
+                "id": "y1",
+                "position": "left"
+              }
+            ],
             "layers": [
               {
                 "id": "dfgth",
                 "type": "line",
-                "fields": ["lin_accl_x"],
+                "fields": [
+                  "lin_accl_x"
+                ],
                 "dataset": "ACC1A",
                 "endTime": "2022-03-02T00:36:00.000000Z",
                 "mission": "GRACEFO",
@@ -52,28 +67,31 @@
               "type": "section",
               "title": "Examples",
               "layout": [
-                { "h": 12, "i": "fghyjqiqii", "w": 12, "x": 0, "y": 0 }
+                {
+                  "i": "fghyjqiqii",
+                  "x": 0,
+                  "y": 0,
+                  "w": 16,
+                  "h": 14
+                }
               ],
               "entities": [
                 {
                   "id": "fghyjqiqii",
                   "type": "table",
-                  "title": "Table",
-                  "applyThresholds": true,
-                  "collapse": "same_day",
-                  "dateFormat": "short",
+                  "title": "Performance Reports v04",
                   "layers": [
                     {
                       "id": "48gnes",
                       "fields": [
                         "resid_rms",
                         "resid_nobs",
-                        "arc_length",
                         "clkdd_nobs",
                         "clkdd_mean",
                         "clkdd_sigma",
                         "clkdd_rms",
-                        "timestamp"
+                        "timestamp",
+                        "arc_length"
                       ],
                       "dataset": "KBR1B_RPT",
                       "endTime": "2023-06-30T23:59:00.000000Z",
@@ -120,7 +138,10 @@
                     },
                     {
                       "id": "48gnew",
-                      "fields": ["lpos_rms_start", "timestamp"],
+                      "fields": [
+                        "lpos_rms_start",
+                        "timestamp"
+                      ],
                       "dataset": "GNV1B_RPT",
                       "endTime": "2023-06-30T23:59:00.000000Z",
                       "mission": "GRACEFO",
@@ -130,7 +151,10 @@
                     },
                     {
                       "id": "48gneq",
-                      "fields": ["lpos_rms_start", "timestamp"],
+                      "fields": [
+                        "lpos_rms_start",
+                        "timestamp"
+                      ],
                       "dataset": "GNV1B_RPT",
                       "endTime": "2023-06-30T23:59:00.000000Z",
                       "mission": "GRACEFO",
@@ -141,126 +165,147 @@
                   ],
                   "columns": [
                     {
+                      "id": "1bcgdwq87y398r4jiotrjgdfs",
                       "field": "resid_rms",
-                      "label": "RMS (mm)",
+                      "label": "",
                       "layerId": "48gnes",
                       "columnGroupId": "ocimaom"
                     },
                     {
-                      "field": "resid_nobs",
+                      "id": "2bcgdwq87y398r4jiotrjgdfs",
+                      "field": "resid_rms",
                       "label": "#obs",
                       "layerId": "48gnes",
                       "columnGroupId": "ocimaom"
                     },
                     {
-                      "field": "arc_length",
+                      "id": "3bcgdwq87y398r4jiotrjgdfs",
+                      "field": "resid_rms",
                       "label": "arc (hr)",
                       "layerId": "48gnes",
                       "columnGroupId": "ocimaom"
                     },
                     {
-                      "field": "clkdd_nobs",
+                      "id": "4bcgdwq87y398r4jiotrjgdfs",
+                      "field": "resid_rms",
                       "label": "#obs",
                       "layerId": "48gnes",
                       "columnGroupId": "nvjnjfk"
                     },
                     {
-                      "field": "clkdd_mean",
+                      "id": "5bcgdwq87y398r4jiotrjgdfs",
+                      "field": "resid_rms",
                       "label": "mean",
                       "layerId": "48gnes",
                       "columnGroupId": "nvjnjfk"
                     },
                     {
-                      "field": "clkdd_sigma",
+                      "id": "6bcgdwq87y398r4jiotrjgdfs",
+                      "field": "resid_rms",
                       "label": "stddev",
                       "layerId": "48gnes",
                       "columnGroupId": "nvjnjfk"
                     },
                     {
-                      "field": "clkdd_rms",
+                      "id": "7bcgdwq87y398r4jiotrjgdfs",
+                      "field": "resid_rms",
                       "label": "RMS",
                       "layerId": "48gnes",
                       "columnGroupId": "nvjnjfk"
                     },
                     {
+                      "id": "8bcgdwq87y398r4jiotrjgdfs",
                       "field": "rms_phase",
                       "label": "rms (mm)",
                       "layerId": "48gnek",
                       "columnGroupId": "zxkzjkj"
                     },
                     {
+                      "id": "9bcgdwq87y398r4jiotrjgdfs",
                       "field": "n_phase",
                       "label": "#obs phase",
                       "layerId": "48gnek",
                       "columnGroupId": "zxkzjkj"
                     },
                     {
+                      "id": "11bcgdwq87y398r4jiotrjgdfs",
                       "field": "per_phase_rej",
                       "label": "%edt phase",
                       "layerId": "48gnek",
                       "columnGroupId": "zxkzjkj"
                     },
                     {
+                      "id": "22bcgdwq87y398r4jiotrjgdfs",
                       "field": "rms_range",
                       "label": "rms (cm)",
                       "layerId": "48gnek",
                       "columnGroupId": "zxkzjkj"
                     },
                     {
+                      "id": "33bcgdwq87y398r4jiotrjgdfs",
                       "field": "n_range",
                       "label": "#obs range",
                       "layerId": "48gnek",
                       "columnGroupId": "zxkzjkj"
                     },
                     {
+                      "id": "44bcgdwq87y398r4jiotrjgdfs",
                       "field": "per_range_rej",
                       "label": "%edt range",
                       "layerId": "48gnek",
                       "columnGroupId": "zxkzjkj"
                     },
                     {
+                      "id": "55bcgdwq87y398r4jiotrjgdfs",
                       "field": "rms_phase",
                       "label": "rms (mm)",
                       "layerId": "48gnep",
                       "columnGroupId": "qhwuwhh"
                     },
                     {
+                      "id": "66bcgdwq87y398r4jiotrjgdfs",
                       "field": "n_phase",
                       "label": "#obs phase",
                       "layerId": "48gnep",
                       "columnGroupId": "qhwuwhh"
                     },
                     {
+                      "id": "77bcgdwq87y398r4jiotrjgdfs",
                       "field": "per_phase_rej",
                       "label": "%edt phase",
                       "layerId": "48gnep",
                       "columnGroupId": "qhwuwhh"
                     },
                     {
+                      "id": "88bcgdwq87y398r4jiotrjgdfs",
                       "field": "rms_range",
                       "label": "rms (cms)",
                       "layerId": "48gnep",
                       "columnGroupId": "qhwuwhh"
                     },
                     {
+                      "id": "99bcgdwq87y398r4jiotrjgdfs",
                       "field": "n_range",
                       "label": "#obs range",
                       "layerId": "48gnep",
                       "columnGroupId": "qhwuwhh"
                     },
                     {
+                      "id": "111bcgdwq87y398r4jiotrjgdfs",
                       "field": "per_range_rej",
                       "label": "%edt range",
                       "layerId": "48gnep",
                       "columnGroupId": "qhwuwhh"
                     },
                     {
+                      "id": "222bcgdwq87y398r4jiotrjgdfs",
                       "field": "lpos_rms_start",
                       "label": "GFO-C (mm)",
                       "layerId": "48gnew",
                       "columnGroupId": "wwwhwiw"
                     },
                     {
+                      "id": "333bcgdwq87y398r4jiotrjgdfs",
                       "field": "lpos_rms_start",
                       "label": "GFO-D (mm)",
                       "layerId": "48gneq",
@@ -268,7 +313,8 @@
                     }
                   ],
                   "compact": true,
-                  "showHeader": false,
+                  "collapse": "same_day",
+                  "dateFormat": "short",
                   "columnGroups": [
                     {
                       "id": "ocimaom",
@@ -280,11 +326,11 @@
                     },
                     {
                       "id": "zxkzjkj",
-                      "name": "GPS Tracking Grace-FO C"
+                      "name": "GPS Tracking GRACE-FO C"
                     },
                     {
                       "id": "qhwuwhh",
-                      "name": "GPS Tracking Grace-FO D"
+                      "name": "GPS Tracking GRACE-FO D"
                     },
                     {
                       "id": "wwwhwiw",
@@ -292,10 +338,11 @@
                     }
                   ],
                   "fitToGridWidth": true,
+                  "applyThresholds": true,
                   "syncWithPageDateRange": true
                 }
               ],
-              "resizable": false,
+              "resizable": true,
               "fullHeight": true,
               "defaultOpen": true
             }
@@ -347,7 +394,9 @@
                             {
                               "id": "5dfgdfgdfg",
                               "type": "line",
-                              "fields": ["lin_accl_x"],
+                              "fields": [
+                                "lin_accl_x"
+                              ],
                               "dataset": "ACC1A",
                               "endTime": "2022-03-02T00:36:00.000000Z",
                               "mission": "GRACEFO",
@@ -362,20 +411,49 @@
                         }
                       ]
                     },
-                    { "dataset": "AHK1A" },
-                    { "dataset": "GNV1A" },
-                    { "dataset": "GPS1A" },
-                    { "dataset": "HRT1A" },
-                    { "dataset": "IHK1A" },
-                    { "dataset": "IMU1A" },
-                    { "dataset": "KBR1A" },
-                    { "dataset": "LHK1A" },
-                    { "dataset": "LRI1A" },
-                    { "dataset": "LSM1A" },
-                    { "dataset": "MAG1A" },
-                    { "dataset": "SCA1A" },
-                    { "dataset": "THR1A", "passGapLimit": 100000000 },
-                    { "dataset": "TNK1A" }
+                    {
+                      "dataset": "AHK1A"
+                    },
+                    {
+                      "dataset": "GNV1A"
+                    },
+                    {
+                      "dataset": "GPS1A"
+                    },
+                    {
+                      "dataset": "HRT1A"
+                    },
+                    {
+                      "dataset": "IHK1A"
+                    },
+                    {
+                      "dataset": "IMU1A"
+                    },
+                    {
+                      "dataset": "KBR1A"
+                    },
+                    {
+                      "dataset": "LHK1A"
+                    },
+                    {
+                      "dataset": "LRI1A"
+                    },
+                    {
+                      "dataset": "LSM1A"
+                    },
+                    {
+                      "dataset": "MAG1A"
+                    },
+                    {
+                      "dataset": "SCA1A"
+                    },
+                    {
+                      "dataset": "THR1A",
+                      "passGapLimit": 100000000
+                    },
+                    {
+                      "dataset": "TNK1A"
+                    }
                   ],
                   "dateRange": {
                     "end": "",
@@ -421,6 +499,491 @@
       "url": "l1a",
       "pages": [
         {
+          "id": "def",
+          "url": "acc",
+          "title": "ACC1A",
+          "sections": [
+            {
+              "id": "sdfdghty",
+              "type": "section",
+              "title": "GRACE-FO Linear Acceleration",
+              "layout": [
+                {
+                  "h": 7,
+                  "i": "sdfghy4ter",
+                  "w": 5,
+                  "x": 0,
+                  "y": 0
+                },
+                {
+                  "h": 7,
+                  "i": "dfgrt43rwe",
+                  "w": 5,
+                  "x": 5,
+                  "y": 0
+                },
+                {
+                  "h": 7,
+                  "i": "dfg43er",
+                  "w": 6,
+                  "x": 10,
+                  "y": 0
+                }
+              ],
+              "entities": [
+                {
+                  "id": "sdfghy4ter",
+                  "type": "chart",
+                  "title": "Linear Acceleration X (m/sec²)",
+                  "yAxes": [
+                    {
+                      "id": "y1",
+                      "position": "left"
+                    }
+                  ],
+                  "layers": [
+                    {
+                      "id": "234567",
+                      "type": "line",
+                      "color": "#4bb1ff",
+                      "fields": [
+                        "lin_accl_x"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "345678",
+                      "type": "line",
+                      "color": "#f14444",
+                      "fields": [
+                        "lin_accl_x"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "D"
+                    }
+                  ],
+                  "syncWithPageDateRange": true
+                },
+                {
+                  "id": "dfgrt43rwe",
+                  "type": "chart",
+                  "title": "Linear Acceleration Y (m/sec²)",
+                  "yAxes": [],
+                  "layers": [
+                    {
+                      "id": "234567",
+                      "type": "line",
+                      "color": "#4bb1ff",
+                      "fields": [
+                        "lin_accl_y"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "2wdfgt4",
+                      "type": "line",
+                      "color": "#f14444",
+                      "fields": [
+                        "lin_accl_y"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "D"
+                    }
+                  ],
+                  "syncWithPageDateRange": true
+                },
+                {
+                  "id": "dfg43er",
+                  "type": "chart",
+                  "title": "Linear Acceleration Z (m/sec²)",
+                  "yAxes": [],
+                  "layers": [
+                    {
+                      "id": "3wefsdv",
+                      "type": "line",
+                      "color": "#4bb1ff",
+                      "fields": [
+                        "lin_accl_z"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "3rwefv",
+                      "type": "line",
+                      "color": "#f14444",
+                      "fields": [
+                        "lin_accl_z"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "D"
+                    }
+                  ],
+                  "syncWithPageDateRange": true
+                }
+              ],
+              "defaultOpen": true,
+              "enableHeader": true
+            },
+            {
+              "id": "sdr4wdf",
+              "type": "section",
+              "title": "GRACE-FO Angular Acceleration",
+              "layout": [
+                {
+                  "h": 8,
+                  "i": "sdfer34wefsd",
+                  "w": 5,
+                  "x": 0,
+                  "y": 0
+                },
+                {
+                  "h": 8,
+                  "i": "fsdr4efd",
+                  "w": 5,
+                  "x": 5,
+                  "y": 0
+                },
+                {
+                  "h": 8,
+                  "i": "sdfer4edf",
+                  "w": 6,
+                  "x": 10,
+                  "y": 0
+                }
+              ],
+              "entities": [
+                {
+                  "id": "sdfer34wefsd",
+                  "type": "chart",
+                  "title": "Angular Acceleration X (m/sec²)",
+                  "yAxes": [],
+                  "layers": [
+                    {
+                      "id": "r4redgbv",
+                      "type": "line",
+                      "color": "#4bb1ff",
+                      "fields": [
+                        "ang_accl_x"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "sfdr34red",
+                      "type": "line",
+                      "color": "#f14444",
+                      "fields": [
+                        "ang_accl_x"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "D"
+                    }
+                  ],
+                  "syncWithPageDateRange": true
+                },
+                {
+                  "id": "fsdr4efd",
+                  "type": "chart",
+                  "title": "Angular Acceleration Y (m/sec²)",
+                  "yAxes": [],
+                  "layers": [
+                    {
+                      "id": "sdfer4ed",
+                      "type": "line",
+                      "color": "#4bb1ff",
+                      "fields": [
+                        "ang_accl_y"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "ewfsvc",
+                      "type": "line",
+                      "color": "#f14444",
+                      "fields": [
+                        "ang_accl_y"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "D"
+                    }
+                  ],
+                  "syncWithPageDateRange": true
+                },
+                {
+                  "id": "sdfer4edf",
+                  "type": "chart",
+                  "title": "Angular Acceleration Z (m/sec²)",
+                  "yAxes": [],
+                  "layers": [
+                    {
+                      "id": "sdfxv",
+                      "type": "line",
+                      "color": "#4bb1ff",
+                      "fields": [
+                        "ang_accl_z"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "sdfsdfsf",
+                      "type": "line",
+                      "color": "#f14444",
+                      "fields": [
+                        "ang_accl_z"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "2022-03-02T00:36:00.000000Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "startTime": "2022-03-02T00:26:00.000000Z",
+                      "instrument": "D"
+                    }
+                  ],
+                  "syncWithPageDateRange": true
+                }
+              ],
+              "defaultOpen": true,
+              "enableHeader": true
+            }
+          ]
+        }
+      ],
+      "title": "L1"
+    },
+    {
+      "id": "1652dfb9-4e51-4268-95d8-6f6de9729740",
+      "url": "development-area",
+      "pages": [
+        {
+          "id": "bbc0ef16-eba0-47c6-af59-a492ae8025f5",
+          "url": "tables",
+          "title": "Table Testing",
+          "sections": [
+            {
+              "id": "ccd2ed2a-012c-40ef-ad7f-c6ac9fe2ca80",
+              "title": "New Section",
+              "layout": [
+                {
+                  "h": 9,
+                  "i": "7954fe24-c8a7-453c-8a46-bf8937e105a5",
+                  "w": 16,
+                  "x": 0,
+                  "y": 0
+                },
+                {
+                  "h": 7,
+                  "i": "82d63ccf-49c6-416a-be1f-26d81edf72a7",
+                  "w": 16,
+                  "x": 0,
+                  "y": 9
+                }
+              ],
+              "entities": [
+                {
+                  "id": "7954fe24-c8a7-453c-8a46-bf8937e105a5",
+                  "type": "table",
+                  "title": "New Entity",
+                  "layers": [
+                    {
+                      "id": "a6a0c326-42af-4093-94e5-c2fa5ab815af",
+                      "fields": [
+                        "ang_accl_x"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "channels": [],
+                      "startTime": "",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "75b25a7b-4d8e-4e20-ab74-394f2655a636",
+                      "fields": [
+                        "lin_accl_y",
+                        "lin_accl_x",
+                        "lin_accl_z"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "channels": [],
+                      "startTime": "",
+                      "instrument": "D"
+                    }
+                  ],
+                  "columns": [
+                    {
+                      "id": "3e31334d-c834-4f95-a7d9-4d3ba5cd09bc",
+                      "field": "ang_accl_x",
+                      "label": "",
+                      "layerId": "a6a0c326-42af-4093-94e5-c2fa5ab815af"
+                    },
+                    {
+                      "id": "bc853b12-8647-4745-bf52-d9af97b7f585",
+                      "field": "lin_accl_y",
+                      "label": "",
+                      "layerId": "75b25a7b-4d8e-4e20-ab74-394f2655a636"
+                    },
+                    {
+                      "id": "523e5bf5-c265-4cdf-a363-303c41e8efc7",
+                      "field": "lin_accl_x",
+                      "label": "",
+                      "layerId": "75b25a7b-4d8e-4e20-ab74-394f2655a636"
+                    },
+                    {
+                      "id": "60fa7d2c-212c-49e0-8a65-3fe666cd768c",
+                      "field": "lin_accl_y",
+                      "label": "",
+                      "layerId": "75b25a7b-4d8e-4e20-ab74-394f2655a636"
+                    },
+                    {
+                      "id": "34070d92-4247-4ef2-8d8a-a12c3261c665",
+                      "field": "lin_accl_z",
+                      "label": "",
+                      "layerId": "75b25a7b-4d8e-4e20-ab74-394f2655a636"
+                    }
+                  ],
+                  "compact": false,
+                  "fitToGridWidth": true,
+                  "applyThresholds": false,
+                  "syncWithPageDateRange": true
+                },
+                {
+                  "id": "82d63ccf-49c6-416a-be1f-26d81edf72a7",
+                  "type": "table",
+                  "title": "New Entity",
+                  "layers": [
+                    {
+                      "id": "a6a0c326-42af-4093-94e5-c2fa5ab815af",
+                      "fields": [
+                        "ang_accl_x"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "channels": [],
+                      "startTime": "",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "75b25a7b-4d8e-4e20-ab74-394f2655a636",
+                      "fields": [
+                        "lin_accl_y",
+                        "lin_accl_x",
+                        "lin_accl_z"
+                      ],
+                      "dataset": "ACC1A",
+                      "endTime": "",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "channels": [],
+                      "startTime": "",
+                      "instrument": "D"
+                    }
+                  ],
+                  "columns": [
+                    {
+                      "id": "3e31334d-c834-4f95-a7d9-4d3ba5cd09bc",
+                      "field": "ang_accl_x",
+                      "label": "",
+                      "layerId": "a6a0c326-42af-4093-94e5-c2fa5ab815af"
+                    },
+                    {
+                      "id": "bc853b12-8647-4745-bf52-d9af97b7f585",
+                      "field": "lin_accl_y",
+                      "label": "",
+                      "layerId": "75b25a7b-4d8e-4e20-ab74-394f2655a636"
+                    },
+                    {
+                      "id": "523e5bf5-c265-4cdf-a363-303c41e8efc7",
+                      "field": "lin_accl_x",
+                      "label": "",
+                      "layerId": "75b25a7b-4d8e-4e20-ab74-394f2655a636"
+                    },
+                    {
+                      "id": "60fa7d2c-212c-49e0-8a65-3fe666cd768c",
+                      "field": "lin_accl_y",
+                      "label": "",
+                      "layerId": "75b25a7b-4d8e-4e20-ab74-394f2655a636"
+                    },
+                    {
+                      "id": "34070d92-4247-4ef2-8d8a-a12c3261c665",
+                      "field": "lin_accl_z",
+                      "label": "",
+                      "layerId": "75b25a7b-4d8e-4e20-ab74-394f2655a636"
+                    }
+                  ],
+                  "compact": false,
+                  "fitToGridWidth": true,
+                  "applyThresholds": false,
+                  "syncWithPageDateRange": true
+                }
+              ],
+              "defaultOpen": true,
+              "enableHeader": true
+            }
+          ],
+          "dateFormat": "long"
+        },
+        {
           "id": "abc",
           "url": "configuration_examples",
           "title": "Configuration Examples",
@@ -431,61 +994,67 @@
               "title": "Examples",
               "layout": [
                 {
+                  "h": 7,
                   "i": "hisudhis",
+                  "w": 8,
                   "x": 0,
-                  "y": 2,
-                  "w": 6,
-                  "h": 2
+                  "y": 7
                 },
                 {
+                  "h": 7,
                   "i": "sdfdgfhg",
-                  "x": 6,
-                  "y": 0,
-                  "w": 6,
-                  "h": 2
+                  "w": 8,
+                  "x": 8,
+                  "y": 0
                 },
                 {
+                  "h": 7,
                   "i": "sdf23edx",
+                  "w": 8,
                   "x": 0,
-                  "y": 0,
-                  "w": 6,
-                  "h": 2
+                  "y": 0
                 },
                 {
+                  "h": 6,
                   "i": "3edfghtr",
+                  "w": 8,
                   "x": 0,
-                  "y": 4,
-                  "w": 6,
-                  "h": 2
+                  "y": 14
                 },
                 {
+                  "h": 6,
                   "i": "3efgtre",
-                  "x": 6,
-                  "y": 2,
-                  "w": 6,
-                  "h": 2
+                  "w": 8,
+                  "x": 8,
+                  "y": 14
                 },
-                { "i": "23eriufhdnjkw", "x": 8, "y": 1, "w": 6, "h": 2 },
                 {
+                  "h": 7,
+                  "i": "23eriufhdnjkw",
+                  "w": 8,
+                  "x": 8,
+                  "y": 7
+                },
+                {
+                  "h": 7,
                   "i": "sfrgtef",
-                  "x": 6,
-                  "y": 6,
-                  "w": 6,
-                  "h": 2
-                },
-                {
-                  "i": "hgjhnfgdfede",
+                  "w": 8,
                   "x": 0,
-                  "y": 6,
-                  "w": 6,
-                  "h": 2
+                  "y": 27
                 },
                 {
+                  "h": 7,
+                  "i": "hgjhnfgdfede",
+                  "w": 8,
+                  "x": 0,
+                  "y": 20
+                },
+                {
+                  "h": 7,
                   "i": "sdfgrtrw",
-                  "x": 6,
-                  "y": 4,
-                  "w": 6,
-                  "h": 2
+                  "w": 8,
+                  "x": 8,
+                  "y": 20
                 }
               ],
               "entities": [
@@ -496,7 +1065,9 @@
                   "layers": [
                     {
                       "id": "3regf",
-                      "fields": ["location"],
+                      "fields": [
+                        "location"
+                      ],
                       "dataset": "ACT1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -531,7 +1102,9 @@
                       "id": "3regf",
                       "type": "line",
                       "color": "#4bb1ff",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACT1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -544,7 +1117,9 @@
                       "id": "3rwefrd",
                       "type": "line",
                       "color": "#f14444",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACT1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -579,7 +1154,9 @@
                       "id": "fdv",
                       "type": "line",
                       "color": "#4bb1ff",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACT1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -592,7 +1169,9 @@
                       "id": "sdfe",
                       "type": "line",
                       "color": "#f14444",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACT1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -605,7 +1184,9 @@
                       "id": "2wedfg",
                       "type": "line",
                       "color": "#11c12b",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACT1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -633,7 +1214,9 @@
                       "id": "fdv",
                       "type": "line",
                       "color": "#4bb1ff",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACC1A",
                       "endTime": "2022-03-02T00:33:35.000000Z",
                       "mission": "GRACEFO",
@@ -648,7 +1231,9 @@
                       "id": "sdfe",
                       "type": "line",
                       "color": "#f14444",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACC1A",
                       "endTime": "2022-03-02T00:33:35.000000Z",
                       "mission": "GRACEFO",
@@ -663,7 +1248,9 @@
                       "id": "2ed",
                       "type": "line",
                       "color": "#11c12b",
-                      "fields": ["lin_accl_z"],
+                      "fields": [
+                        "lin_accl_z"
+                      ],
                       "dataset": "ACC1A",
                       "endTime": "2022-03-02T00:33:35.000000Z",
                       "mission": "GRACEFO",
@@ -691,7 +1278,9 @@
                       "id": "fdv",
                       "type": "line",
                       "color": "#4bb1ff",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACC1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -704,7 +1293,9 @@
                       "id": "sdfe",
                       "type": "line",
                       "color": "#f14444",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACC1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -726,84 +1317,116 @@
                   "id": "23eriufhdnjkw",
                   "type": "chart",
                   "title": "TNK1A Channel Values Example",
-                  "syncWithPageDateRange": false,
-                  "layers": [
-                    {
-                      "id": "fdv",
-                      "mission": "GRACEFO",
-                      "dataset": "GPS1A",
-                      "fields": ["ca_range"],
-                      "type": "line",
-                      "version": "04",
-                      "instrument": "C",
-                      "channels": [
-                        { "id": "ant_id", "value": 0 },
-                        { "id": "prn_id", "value": 1 }
-                      ],
-                      "startTime": "2022-05-31T23:13:11.780Z",
-                      "endTime": "2022-06-02T01:10:18.993Z",
-                      "yAxisId": "y1",
-                      "color": "#4bb1ff"
-                    },
-                    {
-                      "id": "2ergss",
-                      "mission": "GRACEFO",
-                      "dataset": "GPS1A",
-                      "fields": ["ca_range"],
-                      "type": "line",
-                      "version": "04",
-                      "instrument": "C",
-                      "channels": [
-                        { "id": "ant_id", "value": 0 },
-                        { "id": "prn_id", "value": 2 }
-                      ],
-                      "startTime": "2022-05-31T23:13:11.780Z",
-                      "endTime": "2022-06-02T01:10:18.993Z",
-                      "yAxisId": "y1",
-                      "color": "#f14444"
-                    },
-                    {
-                      "id": "2ergss",
-                      "mission": "GRACEFO",
-                      "dataset": "GPS1A",
-                      "fields": ["ca_range"],
-                      "type": "line",
-                      "version": "04",
-                      "instrument": "C",
-                      "channels": [
-                        { "id": "ant_id", "value": 0 },
-                        { "id": "prn_id", "value": 3 }
-                      ],
-                      "startTime": "2022-05-31T23:13:11.780Z",
-                      "endTime": "2022-06-02T01:10:18.993Z",
-                      "yAxisId": "y1",
-                      "color": "#11c12b"
-                    },
-                    {
-                      "id": "2ergss",
-                      "mission": "GRACEFO",
-                      "dataset": "GPS1A",
-                      "fields": ["ca_range"],
-                      "type": "line",
-                      "version": "04",
-                      "instrument": "C",
-                      "channels": [
-                        { "id": "ant_id", "value": 0 },
-                        { "id": "prn_id", "value": 4 }
-                      ],
-                      "startTime": "2022-05-31T23:13:11.780Z",
-                      "endTime": "2022-06-02T01:10:18.993Z",
-                      "yAxisId": "y1",
-                      "color": "#494949"
-                    }
-                  ],
                   "yAxes": [
                     {
                       "id": "y1",
                       "label": "ca_range",
                       "position": "left"
                     }
-                  ]
+                  ],
+                  "layers": [
+                    {
+                      "id": "fdv",
+                      "type": "line",
+                      "color": "#4bb1ff",
+                      "fields": [
+                        "ca_range"
+                      ],
+                      "dataset": "GPS1A",
+                      "endTime": "2022-06-02T01:10:18.993Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "channels": [
+                        {
+                          "id": "ant_id",
+                          "value": 0
+                        },
+                        {
+                          "id": "prn_id",
+                          "value": 1
+                        }
+                      ],
+                      "startTime": "2022-05-31T23:13:11.780Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "2ergss",
+                      "type": "line",
+                      "color": "#f14444",
+                      "fields": [
+                        "ca_range"
+                      ],
+                      "dataset": "GPS1A",
+                      "endTime": "2022-06-02T01:10:18.993Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "channels": [
+                        {
+                          "id": "ant_id",
+                          "value": 0
+                        },
+                        {
+                          "id": "prn_id",
+                          "value": 2
+                        }
+                      ],
+                      "startTime": "2022-05-31T23:13:11.780Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "2ergss",
+                      "type": "line",
+                      "color": "#11c12b",
+                      "fields": [
+                        "ca_range"
+                      ],
+                      "dataset": "GPS1A",
+                      "endTime": "2022-06-02T01:10:18.993Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "channels": [
+                        {
+                          "id": "ant_id",
+                          "value": 0
+                        },
+                        {
+                          "id": "prn_id",
+                          "value": 3
+                        }
+                      ],
+                      "startTime": "2022-05-31T23:13:11.780Z",
+                      "instrument": "C"
+                    },
+                    {
+                      "id": "2ergss",
+                      "type": "line",
+                      "color": "#494949",
+                      "fields": [
+                        "ca_range"
+                      ],
+                      "dataset": "GPS1A",
+                      "endTime": "2022-06-02T01:10:18.993Z",
+                      "mission": "GRACEFO",
+                      "version": "04",
+                      "yAxisId": "y1",
+                      "channels": [
+                        {
+                          "id": "ant_id",
+                          "value": 0
+                        },
+                        {
+                          "id": "prn_id",
+                          "value": 4
+                        }
+                      ],
+                      "startTime": "2022-05-31T23:13:11.780Z",
+                      "instrument": "C"
+                    }
+                  ],
+                  "syncWithPageDateRange": false
                 },
                 {
                   "id": "sfrgtef",
@@ -822,7 +1445,9 @@
                       "type": "line",
                       "color": "#11c12b",
                       "label": "GRACEFO: KBR1A range_accl v04",
-                      "fields": ["range_accl"],
+                      "fields": [
+                        "range_accl"
+                      ],
                       "dataset": "KBR1B",
                       "endTime": "2023-06-01T23:59:58.000000Z",
                       "mission": "GRACEFO",
@@ -836,7 +1461,9 @@
                       "type": "line",
                       "color": "#4bb1ff",
                       "label": "GRACEFO: LRI1B range_accl",
-                      "fields": ["range_accl"],
+                      "fields": [
+                        "range_accl"
+                      ],
                       "dataset": "LRI1B",
                       "endTime": "2023-06-01T23:59:58.000000Z",
                       "mission": "GRACEFO",
@@ -850,7 +1477,9 @@
                       "type": "line",
                       "color": "#f14444",
                       "label": "GRACEFO: range_accl KBR1B-LRI1B",
-                      "fields": ["range_accl"],
+                      "fields": [
+                        "range_accl"
+                      ],
                       "dataset": "KBR1B",
                       "endTime": "2023-06-01T23:59:58.000000Z",
                       "mission": "GRACEFO",
@@ -887,7 +1516,9 @@
                       "type": "line",
                       "color": "#4bb1ff",
                       "label": "GRACEFO C: lin_accl_x v04",
-                      "fields": ["lin_accl_y"],
+                      "fields": [
+                        "lin_accl_y"
+                      ],
                       "dataset": "ACT1B",
                       "endTime": "2023-06-01T23:59:58.000000Z",
                       "mission": "GRACEFO",
@@ -901,7 +1532,9 @@
                       "type": "line",
                       "color": "#11c12b",
                       "label": "GRACEFO D: lin_accl_x v04",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACT1B",
                       "endTime": "2023-06-01T23:59:58.000000Z",
                       "mission": "GRACEFO",
@@ -915,7 +1548,9 @@
                       "type": "line",
                       "color": "#f14444",
                       "label": "GRACEFO C: (lin_accl_x + 23000ms * -1.05) v04",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACT1B",
                       "endTime": "2023-06-01T23:59:58.000000Z",
                       "mission": "GRACEFO",
@@ -947,7 +1582,9 @@
                     {
                       "id": "asdasd",
                       "type": "line",
-                      "fields": ["lin_accl_x"],
+                      "fields": [
+                        "lin_accl_x"
+                      ],
                       "dataset": "ACT1A",
                       "endTime": "2022-03-02T00:36:00.000000Z",
                       "mission": "GRACEFO",
@@ -963,558 +1600,9 @@
               "enableHeader": true
             }
           ]
-        },
-        {
-          "id": "def",
-          "url": "acc",
-          "title": "ACC1A",
-          "sections": [
-            {
-              "id": "sdfdghty",
-              "type": "section",
-              "title": "GRACE-FO Linear Acceleration",
-              "layout": [
-                {
-                  "h": 2,
-                  "i": "sdfghy4ter",
-                  "w": 4,
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "h": 2,
-                  "i": "dfgrt43rwe",
-                  "w": 4,
-                  "x": 4,
-                  "y": 0
-                },
-                {
-                  "h": 2,
-                  "i": "dfg43er",
-                  "w": 4,
-                  "x": 8,
-                  "y": 0
-                }
-              ],
-              "entities": [
-                {
-                  "id": "sdfghy4ter",
-                  "type": "chart",
-                  "title": "Linear Acceleration X (m/sec²)",
-                  "yAxes": [
-                    {
-                      "id": "y1",
-                      "position": "left"
-                    }
-                  ],
-                  "layers": [
-                    {
-                      "id": "234567",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["lin_accl_x"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "yAxisId": "y1",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "345678",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["lin_accl_x"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "yAxisId": "y1",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                },
-                {
-                  "id": "dfgrt43rwe",
-                  "type": "chart",
-                  "title": "Linear Acceleration Y (m/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "234567",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["lin_accl_y"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "yAxisId": "y1",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "2wdfgt4",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["lin_accl_y"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "yAxisId": "y1",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                },
-                {
-                  "id": "dfg43er",
-                  "type": "chart",
-                  "title": "Linear Acceleration Z (m/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "3wefsdv",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["lin_accl_z"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "yAxisId": "y1",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "3rwefv",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["lin_accl_z"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "yAxisId": "y1",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                }
-              ],
-              "defaultOpen": true,
-              "enableHeader": true
-            },
-            {
-              "id": "sdr4wdf",
-              "type": "section",
-              "title": "GRACE-FO Angular Acceleration",
-              "layout": [
-                {
-                  "h": 2,
-                  "i": "sdfer34wefsd",
-                  "w": 4,
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "h": 2,
-                  "i": "fsdr4efd",
-                  "w": 4,
-                  "x": 4,
-                  "y": 0
-                },
-                {
-                  "h": 2,
-                  "i": "sdfer4edf",
-                  "w": 4,
-                  "x": 8,
-                  "y": 0
-                }
-              ],
-              "entities": [
-                {
-                  "id": "sdfer34wefsd",
-                  "type": "chart",
-                  "title": "Angular Acceleration X (m/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "r4redgbv",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["ang_accl_x"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "sfdr34red",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["ang_accl_x"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                },
-                {
-                  "id": "fsdr4efd",
-                  "type": "chart",
-                  "title": "Angular Acceleration Y (m/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "sdfer4ed",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["ang_accl_y"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "ewfsvc",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["ang_accl_y"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                },
-                {
-                  "id": "sdfer4edf",
-                  "type": "chart",
-                  "title": "Angular Acceleration Z (m/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "sdfxv",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["ang_accl_z"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "sdfsdfsf",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["ang_accl_z"],
-                      "dataset": "ACC1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                }
-              ],
-              "defaultOpen": true,
-              "enableHeader": true
-            }
-          ]
-        },
-        {
-          "id": "defsdfsdfsdf",
-          "url": "act",
-          "title": "ACT1A",
-          "sections": [
-            {
-              "id": "3r4egtf",
-              "type": "section",
-              "title": "GRACE-FO Linear Acceleration",
-              "layout": [
-                {
-                  "h": 2,
-                  "i": "3rwegthfg",
-                  "w": 4,
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "h": 2,
-                  "i": "r3wgdf",
-                  "w": 4,
-                  "x": 4,
-                  "y": 0
-                },
-                {
-                  "h": 2,
-                  "i": "234retrhfg",
-                  "w": 4,
-                  "x": 8,
-                  "y": 0
-                }
-              ],
-              "entities": [
-                {
-                  "id": "3rwegthfg",
-                  "type": "chart",
-                  "title": "Linear Acceleration X (nm/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "234567",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["lin_accl_x"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "345678",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["lin_accl_x"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                },
-                {
-                  "id": "r3wgdf",
-                  "type": "chart",
-                  "title": "Linear Acceleration Y (nm/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "234567",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["lin_accl_y"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "2wdfgt4",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["lin_accl_y"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                },
-                {
-                  "id": "234retrhfg",
-                  "type": "chart",
-                  "title": "Linear Acceleration Z (nm/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "32r4etrhyg",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["lin_accl_z"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "2eqsgdf",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["lin_accl_z"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                }
-              ],
-              "defaultOpen": true,
-              "enableHeader": true
-            },
-            {
-              "id": "sdr4wdf",
-              "type": "section",
-              "title": "GRACE-FO Angular Acceleration",
-              "layout": [
-                {
-                  "h": 2,
-                  "i": "32rwergdfn",
-                  "w": 4,
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "h": 2,
-                  "i": "e23wfsdbc",
-                  "w": 4,
-                  "x": 4,
-                  "y": 0
-                },
-                {
-                  "h": 2,
-                  "i": "32r4egtfnhb",
-                  "w": 4,
-                  "x": 8,
-                  "y": 0
-                }
-              ],
-              "entities": [
-                {
-                  "id": "32rwergdfn",
-                  "type": "chart",
-                  "title": "Angular Acceleration X (nm/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "312ewfdg",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["ang_accl_x"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "2eqwfsdbg",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["ang_accl_x"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                },
-                {
-                  "id": "e23wfsdbc",
-                  "type": "chart",
-                  "title": "Angular Acceleration Y (nm/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "3rwefrdgfgb",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["ang_accl_y"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "2eqwfsdb",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["ang_accl_y"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                },
-                {
-                  "id": "32r4egtfnhb",
-                  "type": "chart",
-                  "title": "Angular Acceleration Z (nm/sec²)",
-                  "yAxes": [],
-                  "layers": [
-                    {
-                      "id": "srdgtfhtw3re",
-                      "type": "line",
-                      "color": "#4bb1ff",
-                      "fields": ["ang_accl_z"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "C"
-                    },
-                    {
-                      "id": "23rwegdfds",
-                      "type": "line",
-                      "color": "#f14444",
-                      "fields": ["ang_accl_z"],
-                      "dataset": "ACT1A",
-                      "endTime": "2022-03-02T00:36:00.000000Z",
-                      "mission": "GRACEFO",
-                      "version": "04",
-                      "startTime": "2022-03-02T00:26:00.000000Z",
-                      "instrument": "D"
-                    }
-                  ],
-                  "syncWithPageDateRange": true
-                }
-              ],
-              "defaultOpen": true,
-              "enableHeader": true
-            }
-          ]
         }
       ],
-      "title": "L1"
+      "title": "Development Area"
     }
   ]
 }

--- a/src/components/app/ProductPreviewModal.tsx
+++ b/src/components/app/ProductPreviewModal.tsx
@@ -18,7 +18,7 @@ import Chart from "../entities/chart/Chart";
 import { DateRangePicker } from "../ui/DateRangePicker";
 
 const getProductDisplayName = (product: Product, instrument?: string) => {
-  return `${product.mission} ${instrument || product.instruments[0]} ${
+  return `${product.mission.label} ${instrument || product.instruments[0]} ${
     product.id
   }`;
 };
@@ -114,7 +114,7 @@ export const ProductPreviewModal = ({
         version,
         fields: [field],
         id: "layer1",
-        mission: product.mission,
+        mission: product.mission.id,
         instrument: instrument || product.instruments[0],
         yAxisId: "y1",
         channels,

--- a/src/components/app/ProductTable.tsx
+++ b/src/components/app/ProductTable.tsx
@@ -66,12 +66,12 @@ export const ProductTable = ({
       width: 130,
     },
     {
-      field: "mission",
       filter: "string",
       headerName: "Mission",
       resizable: true,
       sortable: true,
       width: 90,
+      valueGetter: (params) => params.data?.mission.label,
     },
     {
       field: "instruments",

--- a/src/components/app/ProductTable.tsx
+++ b/src/components/app/ProductTable.tsx
@@ -3,6 +3,7 @@ import { ChartLine } from "lucide-react";
 import { Product, ProductField, ProductResolution } from "../../types/api";
 import { DataGridColumnDef } from "../../types/data-grid";
 import { ProductPreview } from "../../types/page";
+import { formatDateGPS } from "../../utilities/time";
 import DataGrid from "../ui/DataGrid/DataGrid";
 import { Tooltip } from "../ui/Tooltip";
 
@@ -88,7 +89,7 @@ export const ProductTable = ({
       sortable: true,
       minWidth: 180,
       valueFormatter: ({ value: dataEnd }) =>
-        dataEnd ? new Date(dataEnd).toGPSString() : "–",
+        dataEnd ? formatDateGPS(new Date(dataEnd)) : "–",
       valueGetter: (params) => params.data?.datasets[0].data_begin,
     },
     {
@@ -98,7 +99,7 @@ export const ProductTable = ({
       sortable: true,
       minWidth: 180,
       valueFormatter: ({ value: dataEnd }) =>
-        dataEnd ? new Date(dataEnd).toGPSString() : "–",
+        dataEnd ? formatDateGPS(new Date(dataEnd)) : "–",
       valueGetter: (params) => params.data?.datasets[0].data_end,
     },
     {

--- a/src/components/app/ProductTable.tsx
+++ b/src/components/app/ProductTable.tsx
@@ -88,7 +88,7 @@ export const ProductTable = ({
       sortable: true,
       minWidth: 180,
       valueFormatter: ({ value: dataEnd }) =>
-        dataEnd ? new Date(dataEnd).toISOString() : "–",
+        dataEnd ? new Date(dataEnd).toGPSString() : "–",
       valueGetter: (params) => params.data?.datasets[0].data_begin,
     },
     {
@@ -98,7 +98,7 @@ export const ProductTable = ({
       sortable: true,
       minWidth: 180,
       valueFormatter: ({ value: dataEnd }) =>
-        dataEnd ? new Date(dataEnd).toISOString() : "–",
+        dataEnd ? new Date(dataEnd).toGPSString() : "–",
       valueGetter: (params) => params.data?.datasets[0].data_end,
     },
     {

--- a/src/components/entities/chart/Chart.tsx
+++ b/src/components/entities/chart/Chart.tsx
@@ -593,7 +593,8 @@ export const Chart = ({
       .filter(({ layer }) => !layer.hidden)
       .map(
         ({ pointsByField, layer, data_count, downsampling_factor, unit }) => {
-          const mission = _mission ?? layer.mission;
+          const missionLabel = getProductForLayer(layer, products)?.mission
+            .label;
           const instrument = _instrument ?? layer.instrument;
           const isLineLayer = isChartLayerLine(layer);
           const isEventLayer = isChartLayerEvent(layer);
@@ -613,7 +614,9 @@ export const Chart = ({
               type: "line",
               label:
                 layer.label ||
-                `${mission} ${instrument} ${layer.dataset} ${layer.fields[0]}${
+                `${missionLabel} ${instrument} ${layer.dataset} ${
+                  layer.fields[0]
+                }${
                   layer.channels && layer.channels.length > 0
                     ? ` (${layer.channels
                         .map((c) => `${c.id}: ${c.value}`)
@@ -992,7 +995,7 @@ export const Chart = ({
 
   const renderTooltip = (
     context: TooltipModel<"line">,
-    mission?: string,
+    missionLabel?: string,
     instrument?: string
   ) => {
     //@ts-expect-error incorrect typings from library
@@ -1018,7 +1021,7 @@ export const Chart = ({
         tooltip={tooltipModel}
         renderHeader={(point) => (
           <>
-            {mission ?? point.dataset.layer.mission}{" "}
+            {missionLabel ?? point.dataset.layer.mission}{" "}
             {instrument ?? point.dataset.layer.instrument}{" "}
             {point.dataset.layer.dataset}{" "}
             {point.dataset.layer.fields.length === 1

--- a/src/components/entities/chart/ChartTooltip.tsx
+++ b/src/components/entities/chart/ChartTooltip.tsx
@@ -1,6 +1,7 @@
 import { TooltipItem, TooltipModel } from "chart.js";
 import React, { useLayoutEffect, useRef, useState } from "react";
 import { DataLayer } from "../../../types/view";
+import { formatDateGPS } from "../../../utilities/time";
 import { formatYValue } from "../../../utilities/view";
 import { CustomChartData } from "./Chart";
 import "./ChartTooltip.css";
@@ -90,9 +91,9 @@ export const ChartTooltip = ({
     >
       <div className="chart-tooltip-content bg-foreground">
         <div className="chart-tooltip-x text-white font-bold">
-          {new Date(
-            tooltip.dataPoints[0].parsed.x as unknown as number
-          ).toGPSString()}
+          {formatDateGPS(
+            new Date(tooltip.dataPoints[0].parsed.x as unknown as number)
+          )}
         </div>
         <div className="chart-tooltip-rows">
           {tooltip.dataPoints.map((point, i) => {

--- a/src/components/entities/chart/ChartTooltip.tsx
+++ b/src/components/entities/chart/ChartTooltip.tsx
@@ -92,7 +92,7 @@ export const ChartTooltip = ({
         <div className="chart-tooltip-x text-white font-bold">
           {new Date(
             tooltip.dataPoints[0].parsed.x as unknown as number
-          ).toISOString()}
+          ).toGPSString()}
         </div>
         <div className="chart-tooltip-rows">
           {tooltip.dataPoints.map((point, i) => {

--- a/src/components/page/ViewPage.tsx
+++ b/src/components/page/ViewPage.tsx
@@ -23,6 +23,7 @@ import {
   SectionLayout,
   Section as SectionType,
 } from "../../types/view";
+import { getMissions } from "../../utilities/api";
 import { generateUUID } from "../../utilities/generic";
 import {
   createEntity,
@@ -81,6 +82,14 @@ export const ViewPage = ({
   const [pageOptions, setPageOptions] = useState<PageOptions>({
     showHoverDate: true,
   });
+
+  const [missionsObj, setMissionsObj] = useState<
+    { id: string; label: string }[]
+  >([]);
+  useEffect(() => {
+    const controller = new AbortController();
+    getMissions(controller.signal).then((data) => setMissionsObj(data));
+  }, []);
 
   const confirm = useConfirm();
 
@@ -389,7 +398,8 @@ export const ViewPage = ({
                   key={`${mission}_${instrument}`}
                   value={`${mission}_${instrument}`}
                 >
-                  {mission}&nbsp;
+                  {missionsObj.find((m) => m.id === mission)?.label || mission}
+                  &nbsp;
                   {instrument}
                 </Tabs.Trigger>
               ))}

--- a/src/components/page/ViewPage.tsx
+++ b/src/components/page/ViewPage.tsx
@@ -23,7 +23,6 @@ import {
   SectionLayout,
   Section as SectionType,
 } from "../../types/view";
-import { getMissions } from "../../utilities/api";
 import { generateUUID } from "../../utilities/generic";
 import {
   createEntity,
@@ -41,6 +40,7 @@ import Section from "./Section";
 export declare type PageProps = {
   dateBounds?: DateRange;
   loadingInitialData: boolean;
+  missions: { id: string; label: string }[];
   onPageChange: (page: PageType) => void;
   onSetProductPreview: (productPreview: ProductPreview) => void;
   products: Product[];
@@ -54,6 +54,7 @@ export const ViewPage = ({
     end: "2050-12-01T00:00:00Z",
   },
   products,
+  missions,
   loadingInitialData,
   viewPage,
   onPageChange,
@@ -82,14 +83,6 @@ export const ViewPage = ({
   const [pageOptions, setPageOptions] = useState<PageOptions>({
     showHoverDate: true,
   });
-
-  const [missionsObj, setMissionsObj] = useState<
-    { id: string; label: string }[]
-  >([]);
-  useEffect(() => {
-    const controller = new AbortController();
-    getMissions(controller.signal).then((data) => setMissionsObj(data));
-  }, []);
 
   const confirm = useConfirm();
 
@@ -398,7 +391,7 @@ export const ViewPage = ({
                   key={`${mission}_${instrument}`}
                   value={`${mission}_${instrument}`}
                 >
-                  {missionsObj.find((m) => m.id === mission)?.label || mission}
+                  {missions.find((m) => m.id === mission)?.label || mission}
                   &nbsp;
                   {instrument}
                 </Tabs.Trigger>

--- a/src/components/ui/DateRangePicker.tsx
+++ b/src/components/ui/DateRangePicker.tsx
@@ -21,6 +21,7 @@ import {
 } from "react";
 import { DateRange, TZDate } from "react-day-picker";
 import { DateFormat } from "../../types/view";
+import { formatDateGPS } from "../../utilities/time";
 
 export declare type DateRangePickerProps = {
   dateFormat?: DateFormat;
@@ -47,7 +48,9 @@ export function DateRangePicker({
   const [prevPropDateRange, setPrevPropDateRange] = useState("");
 
   useEffect(() => {
-    const dateRangeString = `${startDate.toGPSString()}_${endDate.toGPSString()}`;
+    const dateRangeString = `${formatDateGPS(startDate)}_${formatDateGPS(
+      endDate
+    )}`;
     if (dateRangeString !== prevPropDateRange) {
       setPrevPropDateRange(dateRangeString);
       setDateRange({
@@ -78,7 +81,7 @@ export function DateRangePicker({
       if (dateFormat === "short") {
         return format(date, "yyyy-MM-dd");
       } else {
-        return date.toGPSString();
+        return formatDateGPS(date);
       }
     },
     [dateFormat]

--- a/src/components/ui/DateRangePicker.tsx
+++ b/src/components/ui/DateRangePicker.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   DateRangePicker as DateRangePickerStellar,
-  formatDateISO,
   parseDateStringISO,
 } from "@nasa-jpl/stellar-react";
 import {
@@ -37,8 +36,8 @@ export function DateRangePicker({
   endDate,
   startDate,
   onChange = () => {},
-  minDate = new Date("2010-01-01T00:00:00Z"),
-  maxDate = new Date("2100-12-01T00:00:00Z"),
+  minDate = new Date("2010-01-01T00:00:00"),
+  maxDate = new Date("2100-12-01T00:00:00"),
 }: DateRangePickerProps) {
   const [dateRange, setDateRange] = useState<DateRange>({
     from: new TZDate(startDate, "UTC"),
@@ -79,7 +78,7 @@ export function DateRangePicker({
       if (dateFormat === "short") {
         return format(date, "yyyy-MM-dd");
       } else {
-        return formatDateISO(date);
+        return format(date, "yyyy-MM-dd'T'HH:mm:ss");
       }
     },
     [dateFormat]
@@ -94,9 +93,10 @@ export function DateRangePicker({
       let dateString = (e.target as HTMLInputElement).value;
       let otherDateString = inputValues[which === "from" ? "to" : "from"];
       if (dateFormat === "short") {
-        dateString += "T00:00:00Z";
-        otherDateString += "T00:00:00Z";
+        dateString += "T00:00:00";
+        otherDateString += "T00:00:00";
       }
+      // TODO: mlucas
       const eventDate = parseDateStringISO(dateString);
       const eventVerb = which === "from" ? "start" : "end";
       const otherDate = parseDateStringISO(otherDateString);

--- a/src/components/ui/DateRangePicker.tsx
+++ b/src/components/ui/DateRangePicker.tsx
@@ -21,6 +21,7 @@ import {
 } from "react";
 import { DateRange, TZDate } from "react-day-picker";
 import { DateFormat } from "../../types/view";
+import { formatDateGPS } from "../../utilities/time";
 
 export declare type DateRangePickerProps = {
   dateFormat?: DateFormat;
@@ -47,7 +48,7 @@ export function DateRangePicker({
   const [prevPropDateRange, setPrevPropDateRange] = useState("");
 
   useEffect(() => {
-    const dateRangeString = `${startDate.toISOString()}_${endDate.toISOString()}`;
+    const dateRangeString = `${startDate.toGPSString()}_${endDate.toGPSString()}`;
     if (dateRangeString !== prevPropDateRange) {
       setPrevPropDateRange(dateRangeString);
       setDateRange({
@@ -78,7 +79,7 @@ export function DateRangePicker({
       if (dateFormat === "short") {
         return format(date, "yyyy-MM-dd");
       } else {
-        return format(date, "yyyy-MM-dd'T'HH:mm:ss");
+        return formatDateGPS(date);
       }
     },
     [dateFormat]
@@ -96,10 +97,14 @@ export function DateRangePicker({
         dateString += "T00:00:00";
         otherDateString += "T00:00:00";
       }
-      // TODO: mlucas
-      const eventDate = parseDateStringISO(dateString);
+      // Treat GPS time string as UTC otherwise 7 hours will be added
+      const eventDate = dateString.endsWith("Z")
+        ? parseDateStringISO(dateString)
+        : parseDateStringISO(dateString + "Z");
       const eventVerb = which === "from" ? "start" : "end";
-      const otherDate = parseDateStringISO(otherDateString);
+      const otherDate = otherDateString.endsWith("Z")
+        ? parseDateStringISO(otherDateString)
+        : parseDateStringISO(otherDateString + "Z");
       const otherDateVerb = which === "from" ? "end" : "start";
       if (!dateString) {
         setDateRangeError(

--- a/src/components/ui/DateRangePicker.tsx
+++ b/src/components/ui/DateRangePicker.tsx
@@ -21,7 +21,6 @@ import {
 } from "react";
 import { DateRange, TZDate } from "react-day-picker";
 import { DateFormat } from "../../types/view";
-import { formatDateGPS } from "../../utilities/time";
 
 export declare type DateRangePickerProps = {
   dateFormat?: DateFormat;
@@ -79,7 +78,7 @@ export function DateRangePicker({
       if (dateFormat === "short") {
         return format(date, "yyyy-MM-dd");
       } else {
-        return formatDateGPS(date);
+        return date.toGPSString();
       }
     },
     [dateFormat]

--- a/src/components/ui/ProductSelector.tsx
+++ b/src/components/ui/ProductSelector.tsx
@@ -68,7 +68,7 @@ export const ProductSelector = ({
   const instruments = [
     ...new Set(
       products
-        .filter((product) => product.mission === newSelectedProduct.mission)
+        .filter((product) => product.mission.id === newSelectedProduct.mission)
         .map((product) => product.instruments)
         .flat()
     ),
@@ -78,7 +78,7 @@ export const ProductSelector = ({
       products
         .filter(
           (product) =>
-            product.mission === newSelectedProduct.mission &&
+            product.mission.id === newSelectedProduct.mission &&
             product.instruments.indexOf(newSelectedProduct.instrument) > -1
         )
         .map((product) => product.id)
@@ -88,7 +88,7 @@ export const ProductSelector = ({
   const product = products.find(
     (product) =>
       product.id === newSelectedProduct.dataset &&
-      product.mission === newSelectedProduct.mission &&
+      product.mission.id === newSelectedProduct.mission &&
       product.instruments.indexOf(newSelectedProduct.instrument) > -1
   );
   const fields = product?.available_fields.filter(fieldFilter) || [];
@@ -101,7 +101,7 @@ export const ProductSelector = ({
     products.find(
       (product) =>
         product.id === newSelectedProduct.dataset &&
-        product.mission === newSelectedProduct.mission &&
+        product.mission.id === newSelectedProduct.mission &&
         product.instruments.indexOf(newSelectedProduct.instrument) > -1
     )?.available_versions || [];
   return (
@@ -111,7 +111,10 @@ export const ProductSelector = ({
           <Label size="sm">Mission</Label>
           <Select
             onValueChange={(value) =>
-              updateSelectedProduct({ ...newSelectedProduct, mission: value })
+              updateSelectedProduct({
+                ...newSelectedProduct,
+                mission: value,
+              })
             }
             value={newSelectedProduct.mission}
           >
@@ -120,8 +123,8 @@ export const ProductSelector = ({
             </SelectTrigger>
             <SelectContent size="xs">
               {missions.sort().map((mission) => (
-                <SelectItem size="xs" value={mission} key={mission}>
-                  {mission}
+                <SelectItem size="xs" value={mission.id} key={mission.id}>
+                  {mission.label}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/routes/RootPage.tsx
+++ b/src/routes/RootPage.tsx
@@ -15,6 +15,7 @@ export default function RootPage() {
   const [view, setView] = useState<View>(_initialView);
   const [viewChanged, setViewChanged] = useState<boolean>(false);
   const [products, setProducts] = useState<Product[]>([]);
+  const [missions, setMissions] = useState<{ id: string; label: string }[]>([]);
   const [loadingInitialData, setLoadingInitialData] = useState<boolean>(true);
   const [productPreview, setProductPreview] = useState<ProductPreview>({
     product: undefined,
@@ -66,6 +67,7 @@ export default function RootPage() {
     const products = await Promise.all(
       missions.map((mission) => getProducts(mission.id, signal))
     );
+    setMissions(missions);
     setProducts(products.flat());
     setLoadingInitialData(false);
   };
@@ -76,6 +78,7 @@ export default function RootPage() {
       setView,
       products,
       setProductPreview,
+      missions,
       loadingInitialData,
       initialView,
     ],
@@ -84,6 +87,7 @@ export default function RootPage() {
       setView,
       products,
       setProductPreview,
+      missions,
       loadingInitialData,
       initialView,
     ]

--- a/src/routes/RootPage.tsx
+++ b/src/routes/RootPage.tsx
@@ -64,7 +64,7 @@ export default function RootPage() {
   const fetchProducts = async (signal: AbortSignal) => {
     const missions = await getMissions(signal);
     const products = await Promise.all(
-      missions.map((mission) => getProducts(mission, signal))
+      missions.map((mission) => getProducts(mission.id, signal))
     );
     setProducts(products.flat());
     setLoadingInitialData(false);

--- a/src/routes/ViewPage.tsx
+++ b/src/routes/ViewPage.tsx
@@ -5,13 +5,21 @@ import { ProductPreview } from "../types/page";
 import { View, Page as ViewPageType } from "../types/view";
 
 export default function ViewPage() {
-  const [view, setView, products, setProductPreview, loadingInitialData] =
+  const [
+    view,
+    setView,
+    products,
+    setProductPreview,
+    missions,
+    loadingInitialData,
+  ] =
     useOutletContext<
       [
         View,
         React.Dispatch<React.SetStateAction<View>>,
         Product[],
         React.Dispatch<React.SetStateAction<ProductPreview>>,
+        { id: string; label: string }[],
         boolean
       ]
     >();
@@ -39,6 +47,7 @@ export default function ViewPage() {
     <Page
       products={products}
       loadingInitialData={loadingInitialData}
+      missions={missions}
       viewPage={page}
       dateBounds={view.config?.dateRangeBounds}
       onSetProductPreview={setProductPreview}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -12,7 +12,10 @@ export type Product = {
   full_id: string;
   id: string;
   instruments: string[];
-  mission: string;
+  mission: {
+    id: string;
+    label: string;
+  };
   processing_level: string;
   /* maximum number of values that the query will return */
   query_result_limit: number;

--- a/src/types/time.ts
+++ b/src/types/time.ts
@@ -2,3 +2,9 @@ export type DateRange = {
   end: string;
   start: string; // ISO timestamp like 2022-12-01T12:00:00
 };
+
+// declare global {
+//   interface Date {
+//     toGPSString(): string;
+//   }
+// }

--- a/src/types/time.ts
+++ b/src/types/time.ts
@@ -3,8 +3,8 @@ export type DateRange = {
   start: string; // ISO timestamp like 2022-12-01T12:00:00
 };
 
-// declare global {
-//   interface Date {
-//     toGPSString(): string;
-//   }
-// }
+declare global {
+  interface Date {
+    toGPSString(): string;
+  }
+}

--- a/src/types/time.ts
+++ b/src/types/time.ts
@@ -2,9 +2,3 @@ export type DateRange = {
   end: string;
   start: string; // ISO timestamp like 2022-12-01T12:00:00
 };
-
-declare global {
-  interface Date {
-    toGPSString(): string;
-  }
-}

--- a/src/utilities/api.ts
+++ b/src/utilities/api.ts
@@ -29,7 +29,14 @@ export const getView = async (signal?: AbortSignal): Promise<View> => {
   }
 };
 
-export const getMissions = async (signal: AbortSignal): Promise<string[]> => {
+export const getMissions = async (
+  signal: AbortSignal
+): Promise<
+  {
+    id: string;
+    label: string;
+  }[]
+> => {
   const url = config.endpoints.data + config.api.data.missions;
   const response = await (
     await fetch(url, { signal, credentials: "include" })
@@ -38,12 +45,12 @@ export const getMissions = async (signal: AbortSignal): Promise<string[]> => {
 };
 
 export const getProducts = async (
-  mission: string,
+  missionId: string,
   signal: AbortSignal
 ): Promise<Product[]> => {
   const url =
     config.endpoints.data +
-    config.api.data.products.replace("{MISSION}", mission);
+    config.api.data.products.replace("{MISSION}", missionId);
   const response = await (
     await fetch(url, { signal, credentials: "include" })
   ).json();
@@ -51,7 +58,7 @@ export const getProducts = async (
 };
 
 export const getData = (
-  mission: string,
+  missionId: string,
   dataset: string,
   instrumentId: string,
   version: string,
@@ -72,7 +79,7 @@ export const getData = (
   const url =
     config.endpoints.data +
     config.api.data.data
-      .replace("{MISSION}", mission)
+      .replace("{MISSION}", missionId)
       .replace("{INSTRUMENT}", instrumentId)
       .replace("{DATASET}", dataset)
       .replace("{VERSION}", version) +

--- a/src/utilities/dataset.test.ts
+++ b/src/utilities/dataset.test.ts
@@ -10,7 +10,7 @@ test("getProductForLayer", () => {
   layer.fields = ["field1"];
 
   const dataset1 = generateTestProduct();
-  dataset1.mission = "foo";
+  dataset1.mission = { id: "foo", label: "foo" };
   dataset1.id = "bar";
   dataset1.available_fields = [
     {
@@ -29,7 +29,7 @@ test("getProductForLayer", () => {
     },
   ];
   const dataset2 = generateTestProduct();
-  dataset2.mission = "foo";
+  dataset2.mission = { id: "foo", label: "foo" };
   dataset2.id = "bar";
   dataset2.available_fields = [
     {
@@ -48,7 +48,7 @@ test("getProductForLayer", () => {
     },
   ];
   const dataset3 = generateTestProduct();
-  dataset3.mission = "foo";
+  dataset3.mission = { id: "foo", label: "foo" };
   dataset3.id = "bat";
   dataset3.available_fields = [
     {
@@ -67,7 +67,7 @@ test("getProductForLayer", () => {
     },
   ];
   const dataset4 = generateTestProduct();
-  dataset4.mission = "cat";
+  dataset4.mission = { id: "cat", label: "cat" };
   dataset4.id = "bat";
   dataset4.available_fields = [
     {
@@ -99,7 +99,7 @@ test("getFieldMetadataForLayer", () => {
   layer.fields = ["field1"];
 
   const dataset1 = generateTestProduct();
-  dataset1.mission = "foo";
+  dataset1.mission = { id: "foo", label: "foo" };
   dataset1.id = "bar";
   dataset1.available_fields = [
     {

--- a/src/utilities/product.ts
+++ b/src/utilities/product.ts
@@ -7,7 +7,7 @@ export function getProductForLayer(
   products: Product[]
 ): Product | undefined {
   return products.find(
-    (d) => layer.mission === d.mission && layer.dataset === d.id
+    (d) => layer.mission === d.mission.id && layer.dataset === d.id
   );
 }
 

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -26,3 +26,23 @@ export function toUTCms(value: string) {
 export function j2ToMs(x: number) {
   return x * 1000 + 946728000000;
 }
+
+// export function formatDateGPS(date: Date) {
+//   console.log("formatting date: ", date);
+//   return date.toISOString().substring(0, 19);
+// }
+
+// /*
+//  * Extend Date prototype to add toGPSString method.
+//  *
+//  * Removes the "Z" from the end of the input GPS date so as to not confuse
+//  * with UTC time and truncates to YYYY-MM-DDTHH:MM:SS format.
+//  *
+//  * @param {Date} Date object in GPS time.
+//  * @return {string} String in GPS format YYYY-MM-DDTHH:MM:SS.
+//  */
+// Date.prototype.toGPSString = function (): string {
+//   const result = this.toISOString().substring(0, 19);
+//   console.log("Result:", result);
+//   return result;
+// };

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -1,3 +1,5 @@
+import { formatDateISO } from "@nasa-jpl/stellar-react";
+
 /**
  * Parses input ISO string to return datetime-local string.
  * e.g. "2022-03-02T00:36:00.000Z" -> "2022-03-02T00:36"
@@ -27,22 +29,24 @@ export function j2ToMs(x: number) {
   return x * 1000 + 946728000000;
 }
 
-// export function formatDateGPS(date: Date) {
-//   console.log("formatting date: ", date);
-//   return date.toISOString().substring(0, 19);
-// }
+/**
+ * Takes Date object and returns date string in GPS time format.
+ * @param {Date} date
+ * @returns {string} format YYYY-MM-DDTHH:MM:SS
+ */
+export function formatDateGPS(date: Date) {
+  return formatDateISO(date).substring(0, 19);
+}
 
-// /*
-//  * Extend Date prototype to add toGPSString method.
-//  *
-//  * Removes the "Z" from the end of the input GPS date so as to not confuse
-//  * with UTC time and truncates to YYYY-MM-DDTHH:MM:SS format.
-//  *
-//  * @param {Date} Date object in GPS time.
-//  * @return {string} String in GPS format YYYY-MM-DDTHH:MM:SS.
-//  */
-// Date.prototype.toGPSString = function (): string {
-//   const result = this.toISOString().substring(0, 19);
-//   console.log("Result:", result);
-//   return result;
-// };
+/*
+ * Extend Date prototype to add toGPSString method.
+ *
+ * Removes the "Z" from the end of the input GPS date so as to not confuse
+ * with UTC time and truncates to YYYY-MM-DDTHH:MM:SS format.
+ *
+ * @param {Date} Date object in GPS time.
+ * @return {string} String in GPS format YYYY-MM-DDTHH:MM:SS.
+ */
+Date.prototype.toGPSString = function (): string {
+  return this.toISOString().substring(0, 19);
+};

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -1,3 +1,5 @@
+import { formatDateISO } from "@nasa-jpl/stellar-react";
+
 /**
  * Parses input ISO string to return datetime-local string.
  * e.g. "2022-03-02T00:36:00.000Z" -> "2022-03-02T00:36"
@@ -27,15 +29,11 @@ export function j2ToMs(x: number) {
   return x * 1000 + 946728000000;
 }
 
-/*
- * Extend Date prototype to add toGPSString method.
- *
- * Removes the "Z" from the end of the input GPS date so as to not confuse
- * with UTC time and truncates to YYYY-MM-DDTHH:MM:SS format.
- *
- * @param {Date} Date object in GPS time.
- * @return {string} String in GPS format YYYY-MM-DDTHH:MM:SS.
+/**
+ * Takes Date object and returns date string in GPS time format.
+ * @param {Date} date
+ * @returns {string} format YYYY-MM-DDTHH:MM:SS
  */
-Date.prototype.toGPSString = function (): string {
-  return this.toISOString().substring(0, 19);
-};
+export function formatDateGPS(date: Date) {
+  return formatDateISO(date).substring(0, 19);
+}

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -1,5 +1,3 @@
-import { formatDateISO } from "@nasa-jpl/stellar-react";
-
 /**
  * Parses input ISO string to return datetime-local string.
  * e.g. "2022-03-02T00:36:00.000Z" -> "2022-03-02T00:36"
@@ -27,15 +25,6 @@ export function toUTCms(value: string) {
  */
 export function j2ToMs(x: number) {
   return x * 1000 + 946728000000;
-}
-
-/**
- * Takes Date object and returns date string in GPS time format.
- * @param {Date} date
- * @returns {string} format YYYY-MM-DDTHH:MM:SS
- */
-export function formatDateGPS(date: Date) {
-  return formatDateISO(date).substring(0, 19);
 }
 
 /*


### PR DESCRIPTION
Updated time displayed throughout the application to GPS rather than UTC. The time provided to the UI was GPS time but when visualized in the UI had the 'Z' trailing character which typically indicates UTC time. This was confusing so the 'Z' was dropped to clearly indicate GPS time. 

Context: GPS and UTC time are similar. GPS time does not account for leap seconds and so is ~20 seconds ahead of UTC time.

Closes #68 