### PR TITLE
Improve grid contrast for perf table #159

### DIFF
--- a/src/components/entities/table/Table.css
+++ b/src/components/entities/table/Table.css
@@ -17,26 +17,65 @@
   font-weight: 700;
 }
 
+/* Alternating row colors for better contrast */
+.table .ag-theme-stellar .ag-row-even {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.table .ag-theme-stellar .ag-row-odd {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+/* Maintain row striping on hover */
+.table .ag-theme-stellar .ag-row-even.ag-row-hover:not(.ag-row-selected) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.table .ag-theme-stellar .ag-row-odd.ag-row-hover:not(.ag-row-selected) {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+/* Row borders for better separation */
+.table .ag-theme-stellar .ag-row {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
 .table .limit-cell {
-  background: rgba(255, 180, 180, 0.6);
-  color: rgb(147, 0, 0);
+  background: rgba(255, 150, 150, 0.85);
+  color: rgb(120, 0, 0);
+  font-weight: 500;
 }
 
 .table .warning-cell {
-  background: rgba(255, 239, 180, 0.6);
-  color: rgb(112, 91, 19);
+  background: rgba(255, 220, 140, 0.85);
+  color: rgb(90, 70, 10);
+  font-weight: 500;
 }
 
-.table .limit-row,
-.table .ag-theme-stellar .ag-row-hover.limit-row:not(.ag-row-selected)::before {
-  background: rgba(255, 180, 180, 0.3);
+/* Limit rows with zebra striping */
+.table .limit-row.ag-row-even,
+.table .ag-theme-stellar .ag-row-hover.limit-row.ag-row-even:not(.ag-row-selected)::before {
+  background: rgba(255, 150, 150, 0.35);
 }
 
-.table .warning-row,
+.table .limit-row.ag-row-odd,
+.table .ag-theme-stellar .ag-row-hover.limit-row.ag-row-odd:not(.ag-row-selected)::before {
+  background: rgba(255, 150, 150, 0.5);
+}
+
+/* Warning rows with zebra striping */
+.table .warning-row.ag-row-even,
 .table
   .ag-theme-stellar
-  .ag-row-hover.warning-row:not(.ag-row-selected)::before {
-  background: rgba(255, 239, 180, 0.3);
+  .ag-row-hover.warning-row.ag-row-even:not(.ag-row-selected)::before {
+  background: rgba(255, 220, 140, 0.35);
+}
+
+.table .warning-row.ag-row-odd,
+.table
+  .ag-theme-stellar
+  .ag-row-hover.warning-row.ag-row-odd:not(.ag-row-selected)::before {
+  background: rgba(255, 220, 140, 0.5);
 }
 
 .table .derived-column {


### PR DESCRIPTION
Per-row contrast before:
<img width="440" height="114" alt="Screenshot 2025-11-12 at 10 47 58 AM" src="https://github.com/user-attachments/assets/f7de4cb1-3408-426e-a923-0962eb8747c1" />

after:
<img width="396" height="101" alt="Screenshot 2025-11-12 at 10 48 04 AM" src="https://github.com/user-attachments/assets/8a8e6fb8-560d-4bc0-84bd-1ad128f2a6cb" />


Outlier contrast before:
<img width="962" height="155" alt="Screenshot 2025-11-12 at 10 47 50 AM" src="https://github.com/user-attachments/assets/5cc88f90-f1de-4551-a070-6ea6ff733f9d" />

after:
<img width="1005" height="191" alt="Screenshot 2025-11-12 at 10 47 43 AM" src="https://github.com/user-attachments/assets/4d8754e4-f2e8-4665-85b3-cc8b3ae4e460" />
