### PR TITLE
Investigate artifacts seen in map over larger time periods #84

### DIFF
--- a/src/components/entities/map/Map.tsx
+++ b/src/components/entities/map/Map.tsx
@@ -36,7 +36,7 @@ export const Map = ({ mapEntity, products, dateRange }: MapProps) => {
   const viewerRef = useRef<CesiumViewer | null>(null);
 
   // Maximum number of points the api can performantly return (TODO: should be a config option)
-  const MAX_POINT_NUMBER = 5000;
+  const MAX_POINT_NUMBER = 55000;
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>();


### PR DESCRIPTION
Issue was happening because of downsampling artifacts really starting to take effect after about a month or so's worth of data.

After discussion with the team, it seems that users are only going to be looking at a week or so of data at a time. I've increased the limits of the map so that for ~1 week of data, we show non-downsampled data.

Performance in both frontend and API with this increased limit seems to be fine so let's see how it goes. Downsampling artifacts will still happen at really extended time periods but it seems like that may not be a use case we need to worry about.